### PR TITLE
Fix markdown titles in ObjC style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#The Objective-C Style Guide for Wordpress Mobile apps
+# The Objective-C Style Guide for Wordpress Mobile apps
 So you want to write some code for WordPress for iOS. That’s nice, thanks a lot. But before that take some minutes to read some tips that will probably make everyone’s life easier. Much of this guide is adapted from [Google's Objective-C Style Guide](http://google-styleguide.googlecode.com/svn/trunk/objcguide.xml). You should read that as well as [Apple's Coding Guidelines for Cocoa](https://developer.apple.com/library/mac/#documentation/Cocoa/Conceptual/CodingGuidelines/CodingGuidelines.html).
 
 ## Before You Commit
@@ -65,7 +65,7 @@ Don't use any of these styles:
           error:arg3];
 ```
 
-###Protocols
+### Protocols
 There should not be a space between the type identifier and the name of the protocol encased in angle brackets.
 This applies to class declarations, instance variables, and method declarations. For example:
 ```objective-c
@@ -76,7 +76,7 @@ This applies to class declarations, instance variables, and method declarations.
 @end
 ```
 
-###Blocks
+### Blocks
 Blocks are preferred to the target-selector pattern when creating callbacks, as it makes code easier to read. Code inside blocks should be indented four spaces.
 There are several appropriate style rules, depending on how long the block is:
 * If the block can fit on one line, no wrapping is necessary.
@@ -202,7 +202,7 @@ Don't declare a series of variables on one line but rather split them up into in
 
 ```
 
-##Naming
+## Naming
 Naming rules are very important in maintainable code. Objective-C method names tend to be very long, but this has the benefit that a block of code can almost read like prose, thus rendering many comments unnecessary.
 
 When writing pure Objective-C code, we mostly follow standard [Objective-C naming rules](http://developer.apple.com/documentation/Cocoa/Conceptual/CodingGuidelines/CodingGuidelines.html).
@@ -221,17 +221,17 @@ Any class, category, method, or variable name may use all capitals for initialis
 }
 ```
 
-###File Names
+### File Names
 File names should reflect the name of the class implementation that they contain—including case.  
 
 File names for categories should include the name of the class being extended, e.g. _NSString+Helpers.h_ or _UIColors+Helpers.h_
 
-###Class Names
+### Class Names
 Class names (along with category and protocol names) should start as uppercase and use mixed case to delimit words.
 
 In application-level code, prefixes on class names should generally be avoided. Having every single class with same prefix impairs readability for no benefit. When designing code to be shared across multiple applications, prefixes are acceptable and recommended (e.g. _WPXMLRPCEncoder_).
 
-###Objective-C Method Names
+### Objective-C Method Names
 Method names should start as lowercase and then use mixed case. Each named parameter should also start as lowercase.  
 The method name should read like a sentence if possible, meaning you should choose parameter names that flow with the method name. (e.g. _convertPoint:fromRect_: or _replaceCharactersInRange:withString:_). See [Apple's Guide to Naming Methods](https://developer.apple.com/library/mac/#documentation/Cocoa/Conceptual/CodingGuidelines/Articles/NamingMethods.html#//apple_ref/doc/uid/20001282-BCIGIJJF) for more details.  
 
@@ -241,7 +241,7 @@ Accessor methods should be named the same as the variable they're "getting", but
 - (id)delegate;    // GOOD
 ```
 
-###Variable Names
+### Variable Names
 Variables names start with a lowercase and use mixed case to delimit words. Instance variables have leading underscores. For example: _myLocalVariable_, *_myInstanceVariable*.  
 
 **Common Variable Names**
@@ -266,7 +266,7 @@ port = [network port];
 **Instance Variables**  
 Instance variables are mixed case and should be prefixed with an underscore e.g. *_usernameTextField*.
 
-###Comments
+### Comments
 Though a pain to write, they are absolutely vital to keeping our code readable. The following rules describe what you should comment and where. But remember: while comments are very important, the best code is self-documenting. Giving sensible names to types and variables is much better than using obscure names and then trying to explain them through comments.  
 
 When writing your comments, write for your audience: the next contributor who will need to understand your code. Be generous—the next one may be you!  
@@ -295,20 +295,20 @@ Additionally, each method in the public interface should have a comment explaini
 
 Document the synchronization assumptions the class makes, if any. If an instance of the class can be accessed by multiple threads, take extra care to document the rules and invariants surrounding multithreaded use.
 
-##Cocoa and Objective-C Features
-###Interface files
+## Cocoa and Objective-C Features
+### Interface files
 
 Interface files should be as short as possible: don't declare instance variables, and declare only properties and methods that need to be exposed to other classes. Everything else should go into an interface extension inside the implementation file. Remember that you don't need to declare private methods anymore with a modern Xcode version.
 
-###Overridden NSObject Method Placement
+### Overridden NSObject Method Placement
 It is strongly recommended and typical practice to place overridden methods of _NSObject_ at the top of an _@implementation_. This commonly applies (but is not limited) to the _init..._, _copyWithZone:_, and _dealloc_ methods. _init_... methods should be grouped together, followed by the _copyWithZone:_ method, and finally the _dealloc_ method.
 
-###Initialization
+### Initialization
 Don't initialize variables to _0_ or _nil_ in the init method; it's redundant.  
 
 All memory for a newly allocated object is initialized to _0_ (except for isa), so don't clutter up the init method by re-initializing variables to _0_ or _nil_.
 
-###Keep the Public API Simple
+### Keep the Public API Simple
 Keep your class simple; avoid "kitchen-sink" APIs. If a method doesn't need to be public, don't make it so.  
 
 ### Use Root Frameworks
@@ -324,7 +324,7 @@ While it may seem tempting to include individual system headers from a framework
 ...
 ```
 
-###Avoid Accessors During init and dealloc
+### Avoid Accessors During init and dealloc
 Instance subclasses may be in an inconsistent state during _init_ and _dealloc_ method execution, so code in those methods should avoid invoking accessors.  
 
 Subclasses have not yet been initialized or have already deallocated when _init_ and _dealloc_ methods execute, making accessor methods potentially unreliable. Whenever practical, directly assign to and release ivars in those methods rather than rely on accessors.
@@ -364,7 +364,7 @@ Subclasses have not yet been initialized or have already deallocated when _init_
     [super dealloc];
 }
 ```
-###Setters copy NSStrings
+### Setters copy NSStrings
 Setters taking an _NSString_, should always copy the string it accepts.  
 
 Never just retain the string. This avoids the caller changing it under you without your knowledge. Don't assume that because you're accepting an _NSString_ that it's not actually an _NSMutableString_.  
@@ -377,12 +377,12 @@ Never just retain the string. This avoids the caller changing it under you witho
 }
 ```
 
-###nil Checks
+### nil Checks
 Use _nil_ checks for logic flow only.  
 
 Use _nil_ checks for logic flow of the application, not for crash prevention. Sending a message to a nil object is handled by the Objective-C runtime. If the method has no return result, you're good to go. However if there is one, there may be differences based on runtime architecture, return size, and OS X version (see Apple's documentation for specifics).
 
-###BOOL Pitfalls
+### BOOL Pitfalls
 Be careful when converting general integral values to _BOOL_. Avoid comparing directly with _YES_.  
 
 _BOOL_ is defined as a signed char in Objective-C which means that it can have values other than _YES_ (1) and _NO_ (0). Do not cast or convert general integral values directly to _BOOL_. Common mistakes include casting or converting an array's size, a pointer value, or the result of a bitwise logic operation to a _BOOL_ which, depending on the value of the last byte of the integral result, could still result in a _NO_ value. When converting a general integral value to a _BOOL_ use ternary operators to return a _YES_ or _NO_ value.  
@@ -467,7 +467,7 @@ NSArray *array = [[NSArray arrayWithObject:@"hello"] retain];
 NSUInteger numberOfItems = array.count;  // not a property
 array.release;                           // not a property
 ```
-###Interfaces Without Instance Variables
+### Interfaces Without Instance Variables
 Omit the empty set of braces on interfaces that do not declare any instance variables.
 ```objective-c
 // Good
@@ -484,7 +484,7 @@ Omit the empty set of braces on interfaces that do not declare any instance vari
 @end
 ```
 
-###NSNumber, NSArray and NSDictionary  Literals
+### NSNumber, NSArray and NSDictionary  Literals
 For projects that use Xcode 4.4 or later with clang, the use of NSNumber, NSArray and NSDictionary [literals](http://clang.llvm.org/docs/ObjectiveCLiterals.html) is allowed and preferred.
 
 NSNumber literals are used just like Objective C string literals. Boxing is used when necessary.
@@ -505,7 +505,7 @@ NSArray *continents = @[@"North America", @"South America", @"Europe", @"Asia", 
 NSDictionary *personInfo = @{ @"name" : @"John Doe", @"age" : @(25) };
 ```
 
-###Constant definitions
+### Constant definitions
 
 Avoid using `#define` for constants, they should be defined using `const`. Constant names should start with an uppercase letter and use mixed case.
 


### PR DESCRIPTION
A lot of the titles in the document didn't have a space between the `#`s and the text and weren't rendered as titles at all.